### PR TITLE
First pass at simplifying database updates

### DIFF
--- a/db_connector.py
+++ b/db_connector.py
@@ -77,10 +77,10 @@ def get_plcs():
     return formatted_plcs
 
 @db_handler.errorhandler(BadRequest)
-def handle_bad_export(e):
-    return 'export_plc posted without export or reload value', 400
+def handle_bad_request(e):
+    return e.description, 400
 
-@db_handler.route("/export_plc/", methods=["GET", "POST"])
+@db_handler.route("/export_plc/", methods=["POST"])
 def export_by_plc():
     """
     Builds a dictionary of one plc's device_ids and their state information and converts
@@ -94,6 +94,7 @@ def export_by_plc():
     }
     """
     plc = request.form.get('plc_select')
+    message = 'Message unset'
     if request.form["PLC"] == "export":
         export_file = "export/exported_" + plc + "-" + str(datetime.datetime.now().isoformat()) + ".json"
         devices = get_devices_by_plc(plc)
@@ -115,7 +116,7 @@ def export_by_plc():
         else:
             message = "Reload successful."
     else:
-        handle_bad_export()
+        raise BadRequest(description=f'export_plc posted with unhandled value {request.form["PLC"]}')
 
     return export_page(message)
 

--- a/db_connector.py
+++ b/db_connector.py
@@ -11,7 +11,7 @@ from flask import render_template, Blueprint, request, redirect, url_for, send_f
 from werkzeug.exceptions import BadRequest
 
 from sqlalchemy.exc import IntegrityError
-from sqlalchemy import insert
+from sqlalchemy import insert, or_
 
 import pprint, json, datetime, traceback
 
@@ -172,7 +172,7 @@ def state_search_results():
         results = session.query(States).all()
         session.close()    
         return render_template('state_table.html', state_content=format_state(results), all_states=True)
-    results = session.query(States).filter(States.name.contains(state_string)).all()
+    results = session.query(States).filter(or_(States.name.contains(state_string), States.id.contains(state_string))).all()
     session.close()    
     if not results:
         return redirect(url_for('db_handler.search'))
@@ -189,7 +189,7 @@ def device_search_results():
         results = session.query(Devices).order_by(Devices.name).all()
         session.close()    
         return render_template('all_devices.html', device_content=format_device(results))
-    results = session.query(Devices).filter(Devices.name.contains(dev_string)).order_by(Devices.name)
+    results = session.query(Devices).filter(or_(Devices.name.contains(dev_string), Devices.device_id.contains(dev_string))).order_by(Devices.name)
     session.close()    
     if not results:
         return render_template('all_devices.html', device_content=format_device(results))

--- a/db_connector.py
+++ b/db_connector.py
@@ -104,8 +104,10 @@ def export_by_plc():
         with open(export_file, 'w') as f:
             f.write(json.dumps(plc_export))
         #return send_file(export_file, as_attachment=True)
-        upload_ret = cli_upload_file(create_parser().parse_args(f"upload-to {plc} --local-file {export_file}".split()))
-        message = plc + f" Export Successful! Upload to plc {bool(upload_ret) * 'un'}successful."
+        message = f"{plc} export successful!"
+    elif request.form["PLC"] == "download":
+        upload_ret = cli_upload_file(create_parser().parse_args(f"upload-to {plc}".split()))
+        message = f"Upload to {plc} {bool(upload_ret) * 'un'}successful."
     elif request.form["PLC"] == "reload":
         reload_ret = cli_reload_parameters(create_parser().parse_args(f"reload {plc}".split()))
         if reload_ret:

--- a/db_connector.py
+++ b/db_connector.py
@@ -8,6 +8,7 @@ from models.device_states import DeviceStates
 from models.history import History
 
 from flask import render_template, Blueprint, request, redirect, url_for, send_file
+from werkzeug.exceptions import BadRequest
 
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy import insert
@@ -75,6 +76,10 @@ def get_plcs():
         formatted_plcs.append(temp[0])
     return formatted_plcs
 
+@db_handler.errorhandler(BadRequest)
+def handle_bad_export(e):
+    return 'export_plc posted without export or reload value', 400
+
 @db_handler.route("/export_plc/", methods=["GET", "POST"])
 def export_by_plc():
     """
@@ -107,6 +112,9 @@ def export_by_plc():
             message = "Reload unsuccessful. Use pmpsdb_client to reload the database."
         else:
             message = "Reload successful."
+    else:
+        handle_bad_export()
+
     return export_page(message)
 
 @db_handler.route("/export_all/", methods=["GET"])

--- a/db_connector.py
+++ b/db_connector.py
@@ -14,6 +14,10 @@ from sqlalchemy import insert
 
 import pprint, json, datetime, traceback
 
+from pmpsdb_client.cli.parser import create_parser
+from pmpsdb_client.cli.transfer_tools import cli_upload_file
+from pmpsdb_client.cli.epics_tools import cli_reload_parameters
+
 db_handler = Blueprint('db_handler', __name__, template_folder='templates')
 
 @db_handler.route("/populate/", methods=["POST"])
@@ -85,16 +89,24 @@ def export_by_plc():
     }
     """
     plc = request.form.get('plc_select')
-    export_file = "export/exported_" + plc + "-" + str(datetime.datetime.now().isoformat()) + ".json"
-    devices = get_devices_by_plc(plc)
-    if not devices:
-        return render_template("config.html", message="Export Failed - No Device Information")
-    export = get_export_data_by_device_ids(devices)
-    plc_export = {plc:export}
-    with open(export_file, 'w') as f:
-        f.write(json.dumps(plc_export))
-    #return send_file(export_file, as_attachment=True)
-    message = plc + " Export Successful!"
+    if request.form["PLC"] == "export":
+        export_file = "export/exported_" + plc + "-" + str(datetime.datetime.now().isoformat()) + ".json"
+        devices = get_devices_by_plc(plc)
+        if not devices:
+            return render_template("config.html", message="Export Failed - No Device Information")
+        export = get_export_data_by_device_ids(devices)
+        plc_export = {plc:export}
+        with open(export_file, 'w') as f:
+            f.write(json.dumps(plc_export))
+        #return send_file(export_file, as_attachment=True)
+        upload_ret = cli_upload_file(create_parser().parse_args(f"upload-to {plc} --local-file {export_file}".split()))
+        message = plc + f" Export Successful! Upload to plc {bool(upload_ret) * 'un'}successful."
+    elif request.form["PLC"] == "reload":
+        reload_ret = cli_reload_parameters(create_parser().parse_args(f"reload {plc}".split()))
+        if reload_ret:
+            message = "Reload unsuccessful. Use pmpsdb_client to reload the database."
+        else:
+            message = "Reload successful."
     return export_page(message)
 
 @db_handler.route("/export_all/", methods=["GET"])

--- a/templates/config.html
+++ b/templates/config.html
@@ -37,7 +37,7 @@
               {% endfor %}
             </select>
             <button type="submit" class="btn btn-light btn-outline-dark rounded"  name="PLC" value="export">Export</button>
-	    <button type="submit" class="btn btn-light btn-outline-dark rounded"  name="PLC" value="reload">Reload</button>
+            <button type="submit" class="btn btn-light btn-outline-dark rounded"  name="PLC" value="reload">Reload</button>
           </div>
         </form>
       </div>

--- a/templates/config.html
+++ b/templates/config.html
@@ -33,10 +33,11 @@
           <div class="input-group">
             <select name=plc_select class="form-select" name="export_plc" method="post" action="/">
               {% for plc in plcs %}
-                <option value= "{{ plc }}" SELECTED>{{ plc }}</option>"
+                <option value= "{{ plc }}" SELECTED>{{ plc }}</option>
               {% endfor %}
             </select>
-            <button type="submit" class="btn btn-light btn-outline-dark rounded"  name="PLC" >Export</button>
+            <button type="submit" class="btn btn-light btn-outline-dark rounded"  name="PLC" value="export">Export</button>
+	    <button type="submit" class="btn btn-light btn-outline-dark rounded"  name="PLC" value="reload">Reload</button>
           </div>
         </form>
       </div>

--- a/templates/config.html
+++ b/templates/config.html
@@ -36,9 +36,11 @@
                 <option value= "{{ plc }}" SELECTED>{{ plc }}</option>
               {% endfor %}
             </select>
-            <button type="submit" class="btn btn-light btn-outline-dark rounded"  name="PLC" value="export">Export</button>
-            <button type="submit" class="btn btn-light btn-outline-dark rounded"  name="PLC" value="reload">Reload</button>
           </div>
+	    <br>
+            <button type="submit" class="btn btn-light btn-outline-dark rounded"  name="PLC" value="export">Export</button>
+            <button type="submit" class="btn btn-light btn-outline-dark rounded"  name="PLC" value="download">Download</button>
+            <button type="submit" class="btn btn-light btn-outline-dark rounded"  name="PLC" value="reload">Reload</button>
         </form>
       </div>
       <div class="col-sm-5">

--- a/templates/config.html
+++ b/templates/config.html
@@ -44,11 +44,11 @@
         </form>
       </div>
       <div class="col-sm-5">
-        <h5>Next Steps</h5>
         <text>
-          This makes the PLC from the database available to the pmpsdb client transfer tool, which will be used to upload the file to the PLC. </p>
-          PLEASE FOLLOW THE NEXT STEPS to download and activate the parameters on the PLC.</p>
-          Reference this confluence page for more information: <a href="https://confluence.slac.stanford.edu/display/L2SI/PMPSDB+Client+Transfer+Tool+Manual" class="external">PMPS Transfer Manual</a>
+          "Export" creates a local database file but does not transfer it to the PLC.</p>
+          "Download" downloads the latest parameters onto the PLC.</p>
+          "Reload" attempts to make the PLC reread the downloaded database file. If successful, the parameters will immediately become active.</p>
+          Reference this confluence page for more information: <a href="https://confluence.slac.stanford.edu/spaces/PCDS/pages/368333906/PMPSDB+Client+Transfer+Tool+Manual" class="external">PMPS Transfer Manual</a>
         </text>
 
       </div>

--- a/templates/search.html
+++ b/templates/search.html
@@ -67,7 +67,7 @@
       <form action="/state_search_results/" method="post">
         <div class="form-group">
           <div class="input-group">
-            <label for="state_name" class="col-2 col-form-label">Name (full or partial):</label>
+            <label for="state_name" class="col-2 col-form-label">Name (full or partial) or ID:</label>
             <span class="col-4">
               <input type="text" class="form-control" name="state_name" id="state_name" value=""></input>
             </span>
@@ -83,7 +83,7 @@
       <form action="/device_search_results/" method="post">
         <div class="form-group">
           <div class="input-group">
-            <label for="device_name" class="col-2 col-form-label">Name (full or partial):</label>
+            <label for="device_name" class="col-2 col-form-label">Name (full or partial) or ID:</label>
             <span class="col-4">
               <input type="text" class="form-control" name="device_name" id="device_name" value=""></input>
             </span>


### PR DESCRIPTION
https://jira.slac.stanford.edu/browse/ECS-6600

- Removed an extraneous quotation mark from config.html, added another button, and gave the reload and export buttons eponymous values
- Made it so the export button (pre-existing) will try to deploy the new export with cli_upload_file, and the new reload button will try and reload them on the plc with cli_reload_file
- Made it so you can search by device id and state id in the search boxes on the main page - Margaret asked for something like this to make it easier to find the database entry for an assertion id of a preemptive reqeust.

Messages are up for consideration. I tested this interactively on psbuild and added a gateway rule to let me write to PLC:XPP:MOTION:DB:REFRESH. Not sure what exactly to do in prod, but I think the easiest way to go is adding rules in other scalar gateways like `PLC:.*:DB:REFRESH ALLOW RWALL 1` and then either putting pspmpsdb on the build subnet or just adding `export EPICS_CA_ADDR_LIST=172.24.3.13:5068` to run_server.sh to let it use the s3df gateway. Open to suggestions
